### PR TITLE
fix bad query when token is for a non-existent relationship

### DIFF
--- a/reltoken.php
+++ b/reltoken.php
@@ -97,7 +97,11 @@ function reltoken_civicrm_tokenValues(&$values, $contactIDs, $job = null, $token
          * 1 => 2
          * 3 => 2
          */
-        
+        // If you're using a token for a relationship this person doesn't have, just skip it
+        // Otherwise you create a query that crushes the system.
+        if (!$relatedContactIDs) {
+          break;
+        }
         $baseToken = preg_replace('/^(.+)___.+$/', '$1', $token);
 //        dsm($baseToken, '$baseToken');
 //        dsm($relatedContactIDs, "\$relatedContactIDs for $token");


### PR DESCRIPTION
I just found out what happens when you try to process a token for a relationship that doesn't exist, and it's not pretty.

The line in question is:
```php
$tokenDetails = CRM_Utils_Token::getTokenDetails($relatedContactIDs, array($baseToken => 1), FALSE, FALSE, NULL, array('contact' => array($baseToken)), 'CRM_Reltoken');
```

If `$relatedContactIDs` is populated, then this query will do the rather sane act of making an API call to retrieve token data from the contacts in that array.  If `$relatedContactIDs` is NOT populated, then `getTokenDetails()` will make an API call to get token details for EVERY contact in the db.  Oops.  Crashes my UI every time.

Anyway, if `$relatedContactIDs` isn't populated, that means that there are no contacts that have the relationship this token is trying to process, so this patch skips it.