### PR TITLE
use continue not break

### DIFF
--- a/reltoken.php
+++ b/reltoken.php
@@ -100,7 +100,7 @@ function reltoken_civicrm_tokenValues(&$values, $contactIDs, $job = null, $token
         // If you're using a token for a relationship this person doesn't have, just skip it
         // Otherwise you create a query that crushes the system.
         if (!$relatedContactIDs) {
-          break;
+          continue;
         }
         $baseToken = preg_replace('/^(.+)___.+$/', '$1', $token);
 //        dsm($baseToken, '$baseToken');


### PR DESCRIPTION
"What idiot put a break here? Ah yes, me."

If you have multiple reltokens that use different relationships, `break` will stop processing all reltokens after the first one with no relationships.  `continue` will just skip the bad token and move on to the next one.