### PR TITLE
handle both Activity Email and CiviMail-style token arrays

### DIFF
--- a/reltoken.php
+++ b/reltoken.php
@@ -131,6 +131,8 @@ function reltoken_civicrm_tokenValues(&$values, $contactIDs, $job = null, $token
  * This method reformats $messageTokens if it detects that the token names are
  * passed as values.
  *
+ * Original code by xurizaemon: https://github.com/xurizaemon/civicrm-core/commit/90539237365ec9ebf36b703116108d50ac79135c
+ *
  * @param array $messageTokens Per TokenProcessor format
  *  [ 'contact' => [ 'checksum', 'contact_id' ] ]
  * @return array Per hook format


### PR DESCRIPTION
At first I thought this was a bug in your extension - but it's really a bug in core.  Given how long the bug has been in core (2016) I think it makes sense to account for it in the extension - especially since this fix won't need changing if the bug ever IS fixed.

Chris Burgess outlines the issue perfectly in [CRM-19758](https://issues.civicrm.org/jira/browse/CRM-19758) - essentially, the array passed to this hook as `$tokens` isn't always in the same format.  As a result, the tokens this extension generates fail on CiviMail (but not quick email, scheduled reminders, etc.)

This adds a helper function ([stolen from Chris Burgess](https://github.com/xurizaemon/civicrm-core/commit/90539237365ec9ebf36b703116108d50ac79135c)) to account for both array formats.

To test:
Create a template with this text:
```
Hi {contact.display_name},

Your employee's name is {related.display_name___reltype_b_Employee_of_Employer_of}
```

* Send an email to any organization contact that has an employee via quick mail.  This should render both tokens correctly.
* Send the same email to the same contact via CiviMail.  Without this patch, the internal token will render correctly but the reltoken will not.