### PR TITLE
fix infinite loop on Civi 5.44+

### DIFF
--- a/reltoken.php
+++ b/reltoken.php
@@ -6,9 +6,14 @@ require_once 'reltoken.civix.php';
  * implementation of CiviCRM hook
  */
 function reltoken_civicrm_tokens(&$tokens) {
+  static $calledOnce = FALSE;
   // Get a list of the standard contact tokens.
   // Note that CRM_Core_SelectValues::contactTokens() will invoke this hook again.
-  $contactTokens = CRM_Core_SelectValues::contactTokens();
+  $contactTokens = [];
+  if (!$calledOnce) {
+    $calledOnce = TRUE;
+    $contactTokens = CRM_Core_SelectValues::contactTokens();
+  }
   $hashedRelationshipTypes = _reltoken_get_hashed_relationship_types();
 
   // For each standard contact token, create a corresponding token for each


### PR DESCRIPTION
This extension causes an infinite loop (w/ eventual OOM error or segfault) anywhere it's called in Civi 5.44+.  https://github.com/civicrm/civicrm-core/pull/21429 is the culprit, `registerTokens()` now calls a new function `getLegacyHookTokens()`.

Static vars aren't pretty but this extension already uses one, and it gets the job done.

To replicate this, go to any mailing screen (including a quick email) on 5.44+ with this extension enabled.