### PR TITLE
rewrite using Symfony token hooks and TokenProcessor

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,14 +14,17 @@
     <url desc="Support">http://github.com/twomice/com.joineryhq.reltoken/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/gpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-12-27</releaseDate>
-  <version>0.3.1</version>
+  <releaseDate>2022-06-27</releaseDate>
+  <version>1.0</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.43</ver>
   </compatibility>
   <comments></comments>
   <civix>
     <namespace>CRM/Reltoken</namespace>
   </civix>
+  <requires>
+    <ext>org.civicrm.flexmailer</ext>
+  </requires>
 </extension>


### PR DESCRIPTION
Welp - someone had to do it eventually, right?

This is a rewrite of reltoken to use the newer Symfony token events, and use TokenProcessor to render tokens.

I added Flexmailer as a dependency because CiviMail without Flexmailer won't use the new Symfony events.

This is meant to be a rewrite following the original logic as closely as possible, and should have comparable performance.  Now that we're using TokenProcessor I think we can render all tokens for a given related contact with a single TokenProcessor, which should yield a modest speed boost.