### PR TITLE
fix rendering, avoid type error

### DIFF
--- a/reltoken.php
+++ b/reltoken.php
@@ -92,9 +92,7 @@ function _reltoken_evaluate_tokens(\Civi\Token\Event\TokenValueEvent $e) {
           $originalRowCid = $originalTokenProcessorContext[$originalRowKey];
           $relatedContactId = ($relatedContactIDsPerContact[$originalRowCid] ?? NULL);
           if ($relatedContactId) {
-            $relatedProcessorRowId = $relatedTokenProcessorCidToRowMap[$relatedContactId];
-            $renderedToken = $relatedTokenProcessor->getRow($relatedProcessorRowId)->render($baseToken);
-            $originalRow->tokens('related', $token, $renderedToken);
+            $originalRow->tokens('related', $token, $renderedToken[$relatedContactId]);
           }
         }
       }


### PR DESCRIPTION
Before this PR, `$renderedToken` is treated as an array on line 85, then as a string on line 96.  This led to a type error.  On closer examination, I also realized we were rendering the same token twice.  So instead of rendering twice, I'm cleaning up the code so we render once, and use the rendered value in the second loop.